### PR TITLE
feat: add migration scripts for PGlite upgrade

### DIFF
--- a/scripts/migration/export-pg16.mjs
+++ b/scripts/migration/export-pg16.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Export data from PGlite 0.2.x (PostgreSQL 16) database
+ * 
+ * This script exports your existing database using PGlite 0.2.x before upgrading.
+ * 
+ * Prerequisites:
+ *   npm install @electric-sql/pglite@0.2.12
+ * 
+ * Usage:
+ *   node export-pg16.mjs [db-path] [output-dir]
+ * 
+ * Example:
+ *   node export-pg16.mjs ~/.pdf-library/library ~/.pdf-library
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { writeFileSync, appendFileSync, existsSync, unlinkSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+
+const args = process.argv.slice(2);
+const dbPath = args[0] || join(process.env.HOME, 'Documents/.pdf-library/library');
+const outputDir = args[1] || dirname(dbPath);
+
+async function main() {
+  console.log('=== PGlite 0.2.x Database Export ===\n');
+  console.log(`Database: ${dbPath}`);
+  console.log(`Output: ${outputDir}\n`);
+
+  // Check if database exists
+  if (!existsSync(dbPath)) {
+    console.error(`Error: Database not found at ${dbPath}`);
+    process.exit(1);
+  }
+
+  // Check PG_VERSION
+  const versionFile = join(dbPath, 'PG_VERSION');
+  if (existsSync(versionFile)) {
+    const version = require('fs').readFileSync(versionFile, 'utf-8').trim();
+    console.log(`PostgreSQL version: ${version}`);
+    if (version !== '16') {
+      console.warn(`Warning: Expected PG version 16, found ${version}`);
+    }
+  }
+
+  console.log('\nOpening database with PGlite 0.2.x...');
+  
+  let db;
+  try {
+    db = await PGlite.create({ dataDir: dbPath });
+  } catch (e) {
+    console.error(`Failed to open database: ${e.message}`);
+    console.error('\nMake sure you have PGlite 0.2.x installed:');
+    console.error('  npm install @electric-sql/pglite@0.2.12');
+    process.exit(1);
+  }
+
+  // Ensure output directory exists
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  // Export documents
+  console.log('\nExporting documents...');
+  const docs = await db.query('SELECT * FROM documents');
+  console.log(`  Found ${docs.rows.length} documents`);
+  
+  const docsFile = join(outputDir, 'backup-documents.json');
+  writeFileSync(docsFile, JSON.stringify(docs.rows, null, 2));
+  console.log(`  Saved to: ${docsFile}`);
+
+  // Count chunks
+  const chunkCount = await db.query('SELECT COUNT(*) as c FROM chunks');
+  const totalChunks = parseInt(chunkCount.rows[0].c);
+  console.log(`\nExporting ${totalChunks} chunks...`);
+
+  // Export chunks in batches
+  const chunksFile = join(outputDir, 'backup-chunks.jsonl');
+  if (existsSync(chunksFile)) unlinkSync(chunksFile);
+
+  const batchSize = 100;
+  let exported = 0;
+
+  for (let offset = 0; offset < totalChunks; offset += batchSize) {
+    const batch = await db.query(
+      `SELECT * FROM chunks ORDER BY id LIMIT ${batchSize} OFFSET ${offset}`
+    );
+    
+    for (const row of batch.rows) {
+      appendFileSync(chunksFile, JSON.stringify(row) + '\n');
+    }
+    
+    exported += batch.rows.length;
+    if (exported % 10000 === 0 || exported === totalChunks) {
+      console.log(`  Progress: ${exported}/${totalChunks}`);
+    }
+  }
+  console.log(`  Saved to: ${chunksFile}`);
+
+  // Try to export embeddings (may fail if vector extension issues)
+  console.log('\nExporting embeddings...');
+  try {
+    const embCount = await db.query('SELECT COUNT(*) as c FROM embeddings');
+    const totalEmb = parseInt(embCount.rows[0].c);
+    console.log(`  Found ${totalEmb} embeddings`);
+
+    if (totalEmb > 0) {
+      const embFile = join(outputDir, 'backup-embeddings.jsonl');
+      if (existsSync(embFile)) unlinkSync(embFile);
+
+      let embExported = 0;
+      for (let offset = 0; offset < totalEmb; offset += batchSize) {
+        const batch = await db.query(
+          `SELECT chunk_id, embedding::text as embedding FROM embeddings ORDER BY chunk_id LIMIT ${batchSize} OFFSET ${offset}`
+        );
+        
+        for (const row of batch.rows) {
+          appendFileSync(embFile, JSON.stringify(row) + '\n');
+        }
+        
+        embExported += batch.rows.length;
+        if (embExported % 5000 === 0 || embExported === totalEmb) {
+          console.log(`  Progress: ${embExported}/${totalEmb}`);
+        }
+      }
+      console.log(`  Saved to: ${embFile}`);
+    }
+  } catch (e) {
+    console.log(`  Skipped: ${e.message}`);
+    console.log('  (Embeddings can be regenerated after import)');
+  }
+
+  await db.close();
+
+  console.log('\n=== Export Complete ===');
+  console.log('\nBackup files:');
+  console.log(`  - ${join(outputDir, 'backup-documents.json')}`);
+  console.log(`  - ${join(outputDir, 'backup-chunks.jsonl')}`);
+  if (existsSync(join(outputDir, 'backup-embeddings.jsonl'))) {
+    console.log(`  - ${join(outputDir, 'backup-embeddings.jsonl')}`);
+  }
+  console.log('\nNext steps:');
+  console.log('  1. Upgrade to PGlite 0.3.x: bun install');
+  console.log('  2. Import data: bun run scripts/migration/import-pg17.ts');
+}
+
+main().catch(e => {
+  console.error('Export failed:', e);
+  process.exit(1);
+});

--- a/scripts/migration/import-pg17.ts
+++ b/scripts/migration/import-pg17.ts
@@ -1,0 +1,284 @@
+#!/usr/bin/env bun
+/**
+ * Import backup data into PGlite 0.3.x (PostgreSQL 17) database
+ *
+ * This script imports data exported from PGlite 0.2.x.
+ *
+ * Usage:
+ *   bun run scripts/migration/import-pg17.ts [backup-dir] [db-path]
+ *
+ * Example:
+ *   bun run scripts/migration/import-pg17.ts ~/.pdf-library ~/.pdf-library/library
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { readFileSync, createReadStream, existsSync } from "fs";
+import { createInterface } from "readline";
+import { join } from "path";
+
+const EMBEDDING_DIM = 1024;
+
+const args = process.argv.slice(2);
+const backupDir = args[0] || join(process.env.HOME!, "Documents/.pdf-library");
+const dbPath = args[1] || join(backupDir, "library");
+
+async function main() {
+  console.log("=== PGlite 0.3.x Database Import ===\n");
+  console.log(`Backup dir: ${backupDir}`);
+  console.log(`Database: ${dbPath}\n`);
+
+  // Check backup files exist
+  const docsFile = join(backupDir, "backup-documents.json");
+  const chunksFile = join(backupDir, "backup-chunks.jsonl");
+
+  if (!existsSync(docsFile)) {
+    console.error(`Error: Documents backup not found: ${docsFile}`);
+    console.error("\nRun the export script first:");
+    console.error("  node scripts/migration/export-pg16.mjs");
+    process.exit(1);
+  }
+
+  if (!existsSync(chunksFile)) {
+    console.error(`Error: Chunks backup not found: ${chunksFile}`);
+    process.exit(1);
+  }
+
+  // Check if database already exists
+  if (existsSync(dbPath)) {
+    const versionFile = join(dbPath, "PG_VERSION");
+    if (existsSync(versionFile)) {
+      const version = readFileSync(versionFile, "utf-8").trim();
+      if (version === "17") {
+        console.error("Error: PG17 database already exists at this location.");
+        console.error("Remove it first if you want to re-import:");
+        console.error(`  rm -r "${dbPath}"`);
+        process.exit(1);
+      }
+    }
+  }
+
+  console.log("Creating new PGlite 0.3.x database...");
+  const db = new PGlite(dbPath, { extensions: { vector } });
+  await db.waitReady;
+
+  console.log("Initializing schema...");
+  await db.exec("CREATE EXTENSION IF NOT EXISTS vector;");
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS documents (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      added_at TIMESTAMPTZ NOT NULL,
+      page_count INTEGER NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      tags JSONB DEFAULT '[]',
+      metadata JSONB DEFAULT '{}'
+    )
+  `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS chunks (
+      id TEXT PRIMARY KEY,
+      doc_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+      page INTEGER NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      content TEXT NOT NULL
+    )
+  `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS embeddings (
+      chunk_id TEXT PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+      embedding vector(${EMBEDDING_DIM}) NOT NULL
+    )
+  `);
+
+  // Create indexes
+  await db.exec(`
+    CREATE INDEX IF NOT EXISTS embeddings_hnsw_idx 
+    ON embeddings USING hnsw (embedding vector_cosine_ops)
+  `);
+  await db.exec(`
+    CREATE INDEX IF NOT EXISTS chunks_content_idx 
+    ON chunks USING gin (to_tsvector('english', content))
+  `);
+  await db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_doc ON chunks(doc_id)`);
+  await db.exec(`CREATE INDEX IF NOT EXISTS idx_docs_path ON documents(path)`);
+
+  console.log("Schema created!\n");
+
+  // Import documents
+  console.log("Importing documents...");
+  const docs = JSON.parse(readFileSync(docsFile, "utf-8"));
+  const docIds = new Set<string>();
+
+  for (const doc of docs) {
+    docIds.add(doc.id);
+    await db.query(
+      `INSERT INTO documents (id, title, path, added_at, page_count, size_bytes, tags, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        doc.id,
+        doc.title,
+        doc.path,
+        doc.added_at,
+        doc.page_count,
+        doc.size_bytes,
+        JSON.stringify(doc.tags || []),
+        JSON.stringify(doc.metadata || {}),
+      ],
+    );
+  }
+  console.log(`  Imported ${docs.length} documents`);
+
+  // Import chunks
+  console.log("\nImporting chunks...");
+  const rl = createInterface({
+    input: createReadStream(chunksFile),
+    crlfDelay: Infinity,
+  });
+
+  let chunkCount = 0;
+  let skipped = 0;
+  let batch: any[] = [];
+  const BATCH_SIZE = 100;
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const chunk = JSON.parse(line);
+
+    // Skip orphaned chunks
+    if (!docIds.has(chunk.doc_id)) {
+      skipped++;
+      continue;
+    }
+
+    batch.push(chunk);
+
+    if (batch.length >= BATCH_SIZE) {
+      await db.exec("BEGIN");
+      for (const c of batch) {
+        await db.query(
+          `INSERT INTO chunks (id, doc_id, page, chunk_index, content)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (id) DO NOTHING`,
+          [c.id, c.doc_id, c.page, c.chunk_index, c.content],
+        );
+      }
+      await db.exec("COMMIT");
+      chunkCount += batch.length;
+      batch = [];
+
+      if (chunkCount % 10000 === 0) {
+        console.log(`  Progress: ${chunkCount} chunks...`);
+      }
+    }
+  }
+
+  // Final batch
+  if (batch.length > 0) {
+    await db.exec("BEGIN");
+    for (const c of batch) {
+      await db.query(
+        `INSERT INTO chunks (id, doc_id, page, chunk_index, content)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (id) DO NOTHING`,
+        [c.id, c.doc_id, c.page, c.chunk_index, c.content],
+      );
+    }
+    await db.exec("COMMIT");
+    chunkCount += batch.length;
+  }
+
+  console.log(`  Imported ${chunkCount} chunks`);
+  if (skipped > 0) {
+    console.log(`  Skipped ${skipped} orphaned chunks`);
+  }
+
+  // Import embeddings if available
+  const embFile = join(backupDir, "backup-embeddings.jsonl");
+  if (existsSync(embFile)) {
+    console.log("\nImporting embeddings...");
+    const embRl = createInterface({
+      input: createReadStream(embFile),
+      crlfDelay: Infinity,
+    });
+
+    let embCount = 0;
+    let embBatch: any[] = [];
+
+    for await (const line of embRl) {
+      if (!line.trim()) continue;
+      const emb = JSON.parse(line);
+      embBatch.push(emb);
+
+      if (embBatch.length >= 50) {
+        await db.exec("BEGIN");
+        for (const e of embBatch) {
+          await db.query(
+            `INSERT INTO embeddings (chunk_id, embedding)
+             VALUES ($1, $2::vector)
+             ON CONFLICT (chunk_id) DO NOTHING`,
+            [e.chunk_id, e.embedding],
+          );
+        }
+        await db.exec("COMMIT");
+        embCount += embBatch.length;
+        embBatch = [];
+
+        if (embCount % 5000 === 0) {
+          console.log(`  Progress: ${embCount} embeddings...`);
+        }
+      }
+    }
+
+    if (embBatch.length > 0) {
+      await db.exec("BEGIN");
+      for (const e of embBatch) {
+        await db.query(
+          `INSERT INTO embeddings (chunk_id, embedding)
+           VALUES ($1, $2::vector)
+           ON CONFLICT (chunk_id) DO NOTHING`,
+          [e.chunk_id, e.embedding],
+        );
+      }
+      await db.exec("COMMIT");
+      embCount += embBatch.length;
+    }
+
+    console.log(`  Imported ${embCount} embeddings`);
+  }
+
+  // Verify
+  const docResult = await db.query<{ c: number }>(
+    "SELECT COUNT(*) as c FROM documents",
+  );
+  const chunkResult = await db.query<{ c: number }>(
+    "SELECT COUNT(*) as c FROM chunks",
+  );
+  const embResult = await db.query<{ c: number }>(
+    "SELECT COUNT(*) as c FROM embeddings",
+  );
+
+  console.log("\n=== Import Complete ===");
+  console.log(`Documents:  ${docResult.rows[0]?.c}`);
+  console.log(`Chunks:     ${chunkResult.rows[0]?.c}`);
+  console.log(`Embeddings: ${embResult.rows[0]?.c}`);
+
+  if (Number(embResult.rows[0]?.c) === 0) {
+    console.log("\nEmbeddings need to be regenerated.");
+    console.log("Run: bun run scripts/migration/regenerate-embeddings.ts");
+  }
+
+  console.log("\nVerify with: pdf-library stats");
+
+  await db.close();
+}
+
+main().catch((e) => {
+  console.error("Import failed:", e);
+  process.exit(1);
+});

--- a/scripts/migration/regenerate-embeddings.ts
+++ b/scripts/migration/regenerate-embeddings.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env bun
+/**
+ * Regenerate embeddings for chunks using Ollama
+ *
+ * This script generates embeddings for chunks that don't have them.
+ * Useful after migrating from PGlite 0.2.x where embeddings couldn't be exported.
+ *
+ * Prerequisites:
+ *   - Ollama running: ollama serve
+ *   - Embedding model: ollama pull mxbai-embed-large
+ *
+ * Usage:
+ *   bun run scripts/migration/regenerate-embeddings.ts [db-path]
+ *
+ * Environment:
+ *   OLLAMA_HOST - Ollama server URL (default: http://localhost:11434)
+ *   OLLAMA_MODEL - Embedding model (default: mxbai-embed-large)
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { join } from "path";
+
+const OLLAMA_HOST = process.env.OLLAMA_HOST || "http://localhost:11434";
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || "mxbai-embed-large";
+const BATCH_SIZE = 5; // Process 5 chunks at a time (balance speed vs memory)
+
+const args = process.argv.slice(2);
+const dbPath =
+  args[0] || join(process.env.HOME!, "Documents/.pdf-library/library");
+
+interface EmbeddingResponse {
+  embedding: number[];
+}
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const response = await fetch(`${OLLAMA_HOST}/api/embeddings`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: OLLAMA_MODEL, prompt: text }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Ollama error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as EmbeddingResponse;
+  return data.embedding;
+}
+
+async function checkOllama(): Promise<boolean> {
+  try {
+    const response = await fetch(`${OLLAMA_HOST}/api/tags`);
+    if (!response.ok) return false;
+
+    // Test embedding generation
+    const testEmb = await getEmbedding("test");
+    console.log(
+      `Ollama ready! Model: ${OLLAMA_MODEL}, Dimension: ${testEmb.length}`,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  console.log("=== Embedding Regeneration ===\n");
+  console.log(`Database: ${dbPath}`);
+  console.log(`Ollama: ${OLLAMA_HOST}`);
+  console.log(`Model: ${OLLAMA_MODEL}\n`);
+
+  // Check Ollama
+  console.log("Checking Ollama...");
+  if (!(await checkOllama())) {
+    console.error("\nOllama not available. Make sure it's running:");
+    console.error("  ollama serve");
+    console.error(`  ollama pull ${OLLAMA_MODEL}`);
+    process.exit(1);
+  }
+
+  // Connect to database
+  console.log("\nConnecting to database...");
+  const db = new PGlite(dbPath, { extensions: { vector } });
+  await db.waitReady;
+
+  // Count chunks needing embeddings
+  const countResult = await db.query<{ c: string }>(`
+    SELECT COUNT(*) as c FROM chunks c
+    LEFT JOIN embeddings e ON e.chunk_id = c.id
+    WHERE e.chunk_id IS NULL
+  `);
+  const total = parseInt(countResult.rows[0]?.c || "0");
+
+  console.log(`Chunks needing embeddings: ${total}`);
+
+  if (total === 0) {
+    console.log("\nAll chunks have embeddings!");
+    await db.close();
+    return;
+  }
+
+  // Estimate time
+  const estimatedMinutes = Math.ceil(total / 15 / 60); // ~15 embeddings/sec
+  console.log(`Estimated time: ~${estimatedMinutes} minutes\n`);
+
+  let processed = 0;
+  let errors = 0;
+  const startTime = Date.now();
+
+  while (processed < total) {
+    // Get batch of chunks without embeddings
+    const batch = await db.query<{ id: string; content: string }>(`
+      SELECT c.id, c.content FROM chunks c
+      LEFT JOIN embeddings e ON e.chunk_id = c.id
+      WHERE e.chunk_id IS NULL
+      LIMIT ${BATCH_SIZE}
+    `);
+
+    if (batch.rows.length === 0) break;
+
+    // Generate embeddings for batch
+    for (const row of batch.rows) {
+      try {
+        const embedding = await getEmbedding(row.content);
+        const vectorStr = `[${embedding.join(",")}]`;
+
+        await db.query(
+          `INSERT INTO embeddings (chunk_id, embedding)
+           VALUES ($1, $2::vector)
+           ON CONFLICT (chunk_id) DO NOTHING`,
+          [row.id, vectorStr],
+        );
+
+        processed++;
+      } catch (e) {
+        errors++;
+        console.error(`Error on chunk ${row.id}: ${e}`);
+      }
+    }
+
+    // Progress update every 100 chunks
+    if (processed % 100 === 0 || processed === total) {
+      const elapsed = (Date.now() - startTime) / 1000;
+      const rate = processed / elapsed;
+      const remaining = (total - processed) / rate;
+      const pct = ((processed / total) * 100).toFixed(1);
+
+      console.log(
+        `Progress: ${processed}/${total} (${pct}%) | ` +
+          `${rate.toFixed(1)}/s | ` +
+          `ETA: ${Math.ceil(remaining / 60)}min`,
+      );
+    }
+  }
+
+  // Final stats
+  const embResult = await db.query<{ c: string }>(
+    "SELECT COUNT(*) as c FROM embeddings",
+  );
+  const finalCount = parseInt(embResult.rows[0]?.c || "0");
+
+  console.log("\n=== Complete ===");
+  console.log(`Embeddings generated: ${processed}`);
+  console.log(`Total embeddings: ${finalCount}`);
+  console.log(`Errors: ${errors}`);
+  console.log(
+    `Time: ${((Date.now() - startTime) / 1000 / 60).toFixed(1)} minutes`,
+  );
+
+  await db.close();
+}
+
+main().catch((e) => {
+  console.error("Regeneration failed:", e);
+  process.exit(1);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,11 +14,7 @@ import {
   LibraryConfig,
   URLFetchError,
 } from "./index.js";
-import {
-  Migration,
-  MigrationLive,
-  MigrationError,
-} from "./services/Migration.js";
+import { Migration, MigrationLive } from "./services/Migration.js";
 
 /**
  * Check if a string is a URL

--- a/src/services/Migration.ts
+++ b/src/services/Migration.ts
@@ -131,19 +131,21 @@ OPTION 1: Fresh Start (Easiest)
 
 OPTION 2: Manual Migration (Preserve Data)
 ───────────────────────────────────────────
-This requires temporarily using PGlite 0.2.x to export your data.
+Migration scripts are provided in the repository.
 
-1. Generate export script:
-   pdf-library migration generate-script > export.sh
+1. Export data using PGlite 0.2.x:
+   cd /path/to/pdf-library
+   npm install @electric-sql/pglite@0.2.12
+   node scripts/migration/export-pg16.mjs
 
-2. Run the export script (requires PGlite 0.2.x):
-   chmod +x export.sh && ./export.sh
+2. Import into PGlite 0.3.x:
+   bun run scripts/migration/import-pg17.ts
 
-3. Import the dump file:
-   pdf-library migration import library-dump.sql
+3. Regenerate embeddings (if needed):
+   bun run scripts/migration/regenerate-embeddings.ts
 
-For detailed instructions, visit:
-https://github.com/yourusername/pdf-library/docs/migration.md
+For detailed instructions, see:
+https://github.com/joelhooks/pdf-library#migration
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 `,


### PR DESCRIPTION
## Summary
Adds migration scripts to help users upgrade from PGlite 0.2.x (PG16) to 0.3.x (PG17).

## Scripts Added

### `scripts/migration/export-pg16.mjs`
Exports data from existing PGlite 0.2.x database:
- Documents, chunks, and embeddings (if possible)
- Outputs JSON/JSONL backup files
- Requires: `npm install @electric-sql/pglite@0.2.12`

### `scripts/migration/import-pg17.ts`
Imports backup data into new PGlite 0.3.x database:
- Creates fresh PG17 database with schema
- Imports documents and chunks
- Imports embeddings if available

### `scripts/migration/regenerate-embeddings.ts`
Regenerates embeddings using Ollama:
- For cases where embeddings couldn't be exported
- Requires Ollama with mxbai-embed-large model
- Shows progress and ETA

## Usage

```bash
# 1. Export from old database (requires PGlite 0.2.x)
npm install @electric-sql/pglite@0.2.12
node scripts/migration/export-pg16.mjs

# 2. Import into new database
bun run scripts/migration/import-pg17.ts

# 3. Regenerate embeddings if needed
bun run scripts/migration/regenerate-embeddings.ts
```

## Also Updated
- Migration service message now references these scripts
- Fixed unused import warning in cli.ts