### PR TITLE
chore: add supply chain hardening defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Supply-chain choke points: changes here can run code in CI, alter dependency resolution, or publish/deploy the app.
+.github/workflows/ @joelhooks
+.github/actions/ @joelhooks
+package.json @joelhooks
+pnpm-lock.yaml @joelhooks
+package-lock.json @joelhooks
+yarn.lock @joelhooks
+bun.lock @joelhooks
+.npmrc @joelhooks
+src/ @joelhooks
+scripts/ @joelhooks

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '43 4 * * 2'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        continue-on-error: true # Code scanning may be unavailable for private repos; keep advisory until enabled.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'bun.lock'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        continue-on-error: true # Private repos may lack dependency-review/GHAS support; keep advisory until enabled.
+        with:
+          fail-on-severity: high

--- a/SECURITY_SUPPLY_CHAIN.md
+++ b/SECURITY_SUPPLY_CHAIN.md
@@ -1,0 +1,23 @@
+# Supply-chain hardening policy
+
+This repo treats dependency, workflow, source, script, and release changes as security-sensitive.
+
+## Required defaults
+
+- Use the committed lockfile with `pnpm install --frozen-lockfile` in CI.
+- For first inspection of unfamiliar dependencies, install with `--ignore-scripts`.
+- Keep lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`, `prepublishOnly`) rare and explicit.
+- GitHub Actions permissions default to read-only; grant write permissions only per job.
+- Release/deploy jobs must not run on `pull_request`, `pull_request_target`, `discussion`, or other user-content events.
+- Require review for `.github/workflows/`, `.github/actions/`, package manifests, lockfiles, `.npmrc`, source files, scripts, and release config.
+
+## Shai-Hulud-style IOC checks
+
+Block and investigate these immediately:
+
+- `setup_bun.js` or `bun_environment.js` appearing unexpectedly in dependencies or project root.
+- New workflow files such as `.github/workflows/discussion.yaml` or `shai-hulud-workflow.yml`.
+- Self-hosted runners named `SHA1HULUD` or unexpected runner registration files under `$HOME/.dev-env/`.
+- Unexpected public repos/descriptions referencing `Sha1-Hulud`, `Shai-hulud Migration`, or `-migration`.
+
+If a compromised package install ran: assume local/user secrets are burned, revoke npm/GitHub/cloud tokens, rotate deploy secrets, compare artifacts against source, and rebuild the machine instead of surgical cleanup theater.


### PR DESCRIPTION
## Summary
- Adds supply-chain hardening defaults for Shai-Hulud / worms-ctrl-style npm and CI attacks.
- Adds CODEOWNERS, GitHub-Actions-only Dependabot, advisory dependency review, advisory CodeQL, and supply-chain policy.
- Avoids package manager/lockfile churn.

## Validation
- YAML parsed locally.
- `pnpm typecheck` passed locally.

Created after ShitRat-authored hardening commit.