### PR TITLE
Add uv package manager installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ ollama pull llama3.2:3b
 ollama serve
 ```
 
+### Install uv Python package manager
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
 ### Install pdf-brain
 
 ```bash


### PR DESCRIPTION
Add instructions for installing the uv Python package manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for installing the `uv` Python package manager using its official installation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->