### PR TITLE
Fix/windows python3 and homedir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { Duration, Effect, Layer } from "effect";
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
 import { basename } from "node:path";
+import { homedir } from "node:os";
 
 import {
   AddOptions,
@@ -107,7 +108,7 @@ export class PDFLibrary extends Effect.Service<PDFLibrary>()("PDFLibrary", {
         Effect.gen(function* () {
           // Resolve path
           const resolvedPath = pdfPath.startsWith("~")
-            ? pdfPath.replace("~", process.env.HOME || "")
+            ? pdfPath.replace("~", (process.env.HOME || homedir()))
             : pdfPath;
 
           // Check if already exists
@@ -336,7 +337,7 @@ export class PDFLibrary extends Effect.Service<PDFLibrary>()("PDFLibrary", {
         Effect.gen(function* () {
           // Resolve path
           const resolvedPath = pdfPath.startsWith("~")
-            ? pdfPath.replace("~", process.env.HOME || "")
+            ? pdfPath.replace("~", (process.env.HOME || homedir()))
             : pdfPath;
 
           // Require existing doc (this is "replace", not "add")

--- a/src/services/MarkdownExtractor.ts
+++ b/src/services/MarkdownExtractor.ts
@@ -7,6 +7,7 @@
 
 import { Context, Effect, Layer, Schema } from "effect";
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkFrontmatter from "remark-frontmatter";
@@ -476,7 +477,7 @@ function chunkText(
  */
 function resolvePath(path: string): string {
   return path.startsWith("~")
-    ? path.replace("~", process.env.HOME || "")
+    ? path.replace("~", (process.env.HOME || homedir()))
     : path;
 }
 

--- a/src/services/PDFExtractor.ts
+++ b/src/services/PDFExtractor.ts
@@ -10,6 +10,7 @@ import {
   LibraryConfig,
 } from "../types.js";
 import { existsSync } from "fs";
+import { homedir } from "node:os";
 
 // ============================================================================
 // Service Definition
@@ -185,7 +186,7 @@ export const PDFExtractorLive = Layer.effect(
         Effect.gen(function* () {
           // Resolve path
           const resolvedPath = path.startsWith("~")
-            ? path.replace("~", process.env.HOME || "")
+            ? path.replace("~", process.env.HOME || homedir())
             : path;
 
           if (!existsSync(resolvedPath)) {
@@ -197,7 +198,7 @@ export const PDFExtractorLive = Layer.effect(
           const result = yield* Effect.tryPromise({
             try: async () => {
               const output =
-                await $`uv run --with pypdf python3 -c ${EXTRACT_SCRIPT} ${resolvedPath}`.text();
+                await $`uv run --with pypdf python -c ${EXTRACT_SCRIPT} ${resolvedPath}`.text();
               return JSON.parse(output) as ExtractedPDF;
             },
             catch: (e) =>
@@ -210,7 +211,7 @@ export const PDFExtractorLive = Layer.effect(
       process: (path: string) =>
         Effect.gen(function* () {
           const resolvedPath = path.startsWith("~")
-            ? path.replace("~", process.env.HOME || "")
+            ? path.replace("~", process.env.HOME || homedir())
             : path;
 
           if (!existsSync(resolvedPath)) {
@@ -222,7 +223,7 @@ export const PDFExtractorLive = Layer.effect(
           const extracted = yield* Effect.tryPromise({
             try: async () => {
               const output =
-                await $`uv run --with pypdf python3 -c ${EXTRACT_SCRIPT} ${resolvedPath}`.text();
+                await $`uv run --with pypdf python -c ${EXTRACT_SCRIPT} ${resolvedPath}`.text();
               return JSON.parse(output) as ExtractedPDF;
             },
             catch: (e) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import { Schema } from "effect";
+import { homedir } from "node:os";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
 
@@ -186,8 +187,8 @@ export class LibraryConfig extends Schema.Class<LibraryConfig>("LibraryConfig")(
   }
 ) {
   static readonly Default = new LibraryConfig({
-    libraryPath: `${process.env.HOME}/Documents/.pdf-library`,
-    dbPath: `${process.env.HOME}/Documents/.pdf-library/library.db`,
+    libraryPath: `${(process.env.HOME || homedir())}/Documents/.pdf-library`,
+    dbPath: `${(process.env.HOME || homedir())}/Documents/.pdf-library/library.db`,
     ollamaModel: process.env.OLLAMA_MODEL || "mxbai-embed-large",
     ollamaHost: process.env.OLLAMA_HOST || "http://localhost:11434",
     chunkSize: 512,
@@ -197,7 +198,7 @@ export class LibraryConfig extends Schema.Class<LibraryConfig>("LibraryConfig")(
   static fromEnv(): LibraryConfig {
     const libraryPath =
       process.env.PDF_LIBRARY_PATH ||
-      `${process.env.HOME}/Documents/.pdf-library`;
+      `${(process.env.HOME || homedir())}/Documents/.pdf-library`;
     return new LibraryConfig({
       libraryPath,
       dbPath: `${libraryPath}/library.db`,
@@ -368,7 +369,7 @@ export class Config extends Schema.Class<Config>("Config")({
  * Preferred config path (~/.config/pdf-brain/config.json unless overridden).
  */
 export function getDefaultConfigPath(): string {
-  const home = process.env.HOME || ".";
+  const home = (process.env.HOME || homedir());
   return `${home}/.config/pdf-brain/config.json`;
 }
 
@@ -378,7 +379,7 @@ export function getDefaultConfigPath(): string {
 export function getLegacyConfigPath(): string {
   const libraryPath =
     process.env.PDF_LIBRARY_PATH ||
-    `${process.env.HOME}/Documents/.pdf-library`;
+    `${(process.env.HOME || homedir())}/Documents/.pdf-library`;
   return `${libraryPath}/config.json`;
 }
 

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -9,10 +9,11 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, chmodSync } from "fs";
 import { join } from "path";
+import { homedir } from "node:os";
 import { logInfo } from "./logger.js";
 
 const REPO = "joelhooks/pdf-brain";
-const STATE_DIR = join(process.env.HOME || "~", ".pdf-brain");
+const STATE_DIR = join((process.env.HOME || homedir()), ".pdf-brain");
 const STATE_FILE = join(STATE_DIR, "update-check.json");
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 1 day
 


### PR DESCRIPTION
## Summary

Two independent fixes for running pdf-brain on Windows, found and verified while setting up a fresh Windows 11 install (both the compiled binary and running from source via Bun).

## Fix 1: `python3` → `python` for uv on Windows

`PDFExtractor.ts` shells out to:

```ts
$`uv run --with pypdf python3 -c ${EXTRACT_SCRIPT} ${resolvedPath}`
```

`uv` does not resolve `python3` as an interpreter name on Windows, only `python`. This made every `pdf-brain add` fail with a generic `PDFExtractionError: ShellError: Failed with exit code 49` — no useful diagnostic, just a swallowed exit code.

Verified directly:
```bash
uv run --with pypdf python -c "print('hello')" # works
uv run --with pypdf python3 -c "print('hello')" # fails on Windows
```
**Does this affect macOS/Linux?** No. Per Astral's own docs on [Python discovery](https://docs.astral.sh/uv/concepts/python-versions/), `uv` checks for executables named `python`, `python3`, or `python3.x` on macOS and Linux — `python` isn't a Windows-only alias, it's one of the names `uv` already searches for on every platform. If no matching interpreter exists at all, `uv` downloads a managed one regardless of which name was requested. So this is a straightforward correctness fix, not a platform trade-off.

## Fix 2: fall back to `os.homedir()` when `HOME` is unset

Several files (`types.ts`, `index.ts`, `PDFExtractor.ts`, `MarkdownExtractor.ts`, `updater.ts`) read `process.env.HOME` directly. Windows doesn't set `HOME` by default, so `pdf-brain init` resolved the library path to the literal string:

```json
"libraryPath": "undefined/Documents/.pdf-library"
```

...which then broke most file operations depending on it. Other call sites had similarly broken fallbacks (`|| ""`, `|| "."`, `|| "~"`) that produced unusable relative paths rather than an actual home directory.

Fix: `process.env.HOME || homedir()` (from `node:os`) everywhere this pattern appears. On macOS/Linux, `HOME` is essentially always set, so `homedir()` is never actually called there — behavior is identical to before on those platforms. It only kicks in as a working fallback where `HOME` is missing, which was already broken before this change. An explicit `HOME` override (e.g. in containers/tests) still takes precedence either way.

## Testing

- Verified end-to-end on Windows 11, Bun 1.3.14, uv (latest): `pdf-brain init` → `pdf-brain add <pdf>` → successful extraction, chunking, and embedding of a real multi-page PDF.
- `bun test` run locally; failures present are pre-existing and caused by missing dependencies in a fresh `bun install` environment (`effect`, `@modelcontextprotocol/sdk`, `@ai-sdk/openai-compatible` not resolving), unrelated to either change in this PR. No test failures point to files touched here.

## Also worth knowing

Separately, I've put together a Windows install script that builds from source via Bun (works around a packaging issue in the compiled Windows binary, where it's missing the `@libsql/win32-x64-msvc` native module) and auto-installs the other Windows-missing dependencies (Poppler, uv, Ollama): ttps://gist.github.com/jamie-peden/f5d98ca0a7b80719faf3ac96275157c4
